### PR TITLE
Travis CI: Upgrade to Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
-sudo: false
 language: python
 cache:
   directories:
     - $HOME/.cache/pip
-before_script:
-  - pip install tox
+env: TOXENV=flake8
 matrix:
   include:
     - python: 3.6
-      env: TOXENV=flake8
-
-install:
-  - pip install -U tox
-script:
-  - tox
+    - python: 3.7
+      dist: xenial
+install: pip install tox
+script: tox

--- a/models/base.py
+++ b/models/base.py
@@ -110,11 +110,11 @@ class BaseModel(Model, metaclass=ModelMeta):
 
     async def set_props_by_key(self, key, value):
         key = self.get_db_key(key)
-        return await(await self.redis).set(key, value)
+        return await (await self.redis).set(key, value)  # noqa: W606
 
     async def get_props_by_key(self, key):
         key = self.get_db_key(key)
-        return await(await self.redis).get(key) or b''
+        return await (await self.redis).get(key) or b''  # noqa: W606
 
     @classmethod
     async def get_or_404(cls, id, sync=False):


### PR DESCRIPTION
[Travis are now recommending removing the ___sudo___ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

__dist: xenial__ is required for Python >= 3.7 (travis-ci/travis-ci#9069)

Flake8 on Python 3.7 generates a false warning on consecutive `await`: https://github.com/PyCQA/pycodestyle/issues/811