### PR TITLE
修复“删除post记录时未同步删除相关post_tag记录”的问题

### DIFF
--- a/views/admin.py
+++ b/views/admin.py
@@ -10,7 +10,7 @@ from sanic_jwt.utils import call as jwt_call
 
 from ext import mako
 from config import PER_PAGE, SHOW_PROFILE
-from models import Post, User, Tag
+from models import Post, User, Tag, PostTag
 from models.user import generate_password
 from models.profile import get_profile, set_profile
 from forms import UserForm, PostForm, ProfileForm
@@ -247,6 +247,9 @@ async def delete(request, post_id):
     if not post:
         return response.json({'r': 0, 'msg': 'Post not exist'})
     await post.delete()
+    post_tags = await PostTag.filter(post_id=post_id).all()
+    for post_tag in post_tags:
+        await post_tag.delete()
     return response.json({'r': 1})
 
 

--- a/views/admin.py
+++ b/views/admin.py
@@ -9,6 +9,7 @@ from sanic_jwt.decorators import instant_config
 from sanic_jwt.utils import call as jwt_call
 
 from ext import mako
+from tortoise.query_utils import Q
 from config import PER_PAGE, SHOW_PROFILE
 from models import Post, User, Tag, PostTag
 from models.user import generate_password
@@ -247,9 +248,7 @@ async def delete(request, post_id):
     if not post:
         return response.json({'r': 0, 'msg': 'Post not exist'})
     await post.delete()
-    post_tags = await PostTag.filter(post_id=post_id).all()
-    for post_tag in post_tags:
-        await post_tag.delete()
+    await PostTag.filter(Q(post_id=post_id)).delete()
     return response.json({'r': 1})
 
 


### PR DESCRIPTION
Fix the 500 error by deleting the post table record and deleting the corresponding post_type record. If you don't delete post_tag, it will trigger a 500 error when clicking on the tag.