### PR TITLE
fix:TypeError when initial RedisSettings

### DIFF
--- a/models/utils.py
+++ b/models/utils.py
@@ -177,5 +177,6 @@ class RedisSettings(_RedisSettings):
     @classmethod
     def from_url(cls, db_url):
         url = _parse_rfc1738_args(db_url)
-        return cls(url['host'], url['port'], int(url['database']),
+        return cls(url['host'], url['port'],
+                   url['database'] and int(url['database']) or 0,
                    url['password'], 1, 5, 1)


### PR DESCRIPTION
Config:
```
REDIS_URL = 'redis://localhost:6379'
```

Traceback
```
Traceback (most recent call last):
  File "/home/ubuntu/lyanna/venv/lib/python3.6/site-packages/sanic/app.py", line 750, in handle_request
    response = await response
  File "/home/ubuntu/lyanna/views/j.py", line 25, in wrapped
    return await f(request, *args, **kwargs)
  File "/home/ubuntu/lyanna/views/j.py", line 35, in create_comment
    comment = await post.add_comment(user['gid'], content)
  File "/home/ubuntu/lyanna/models/comment.py", line 71, in add_comment
    redis = await create_pool(RedisSettings.from_url(REDIS_URL))
  File "/home/ubuntu/lyanna/models/utils.py", line 180, in from_url
    return cls(url['host'], url['port'], int(url['database']),
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

When the database is not specified in `REDIS_URL`, it will be parsed to None value.
So I fixed it by setting default value 0.